### PR TITLE
add support for D-Link DWA-X1850 A1

### DIFF
--- a/os_dep/linux/recv_linux.c
+++ b/os_dep/linux/recv_linux.c
@@ -338,7 +338,11 @@ static int napi_recv(_adapter *padapter, int budget)
 
 #ifdef CONFIG_RTW_GRO
 		if (pregistrypriv->en_gro) {
+			#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0))
+			if (rtw_napi_gro_receive(&padapter->napi, pskb) != GRO_MERGED_FREE)
+			#else
 			if (rtw_napi_gro_receive(&padapter->napi, pskb) != GRO_DROP)
+			#endif
 				rx_ok = _TRUE;
 			goto next;
 		}

--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -137,6 +137,7 @@ static void rtw_dev_shutdown(struct device *dev)
 
 
 #define USB_VENDER_ID_REALTEK		0x0BDA
+#define USB_VENDER_ID_ASUS  		0x0B05
 #define USB_VENDER_ID_DLINK 		0x2001
 
 
@@ -147,6 +148,9 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_REALTEK, 0x8832, 0xff, 0xff, 0xff), .driver_info = RTL8852A},
 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_REALTEK, 0x885A, 0xff, 0xff, 0xff), .driver_info = RTL8852A},
 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_REALTEK, 0x885C, 0xff, 0xff, 0xff), .driver_info = RTL8852A},
+
+	/*=== ASUS USB-AX56 =======*/
+	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_ASUS,    0x1997, 0xff, 0xff, 0xff), .driver_info = RTL8852A},
 
 	/*=== D-Link DWA-X1850 ====*/
 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_DLINK,   0x3321, 0xff, 0xff, 0xff), .driver_info = RTL8852A},

--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -137,6 +137,7 @@ static void rtw_dev_shutdown(struct device *dev)
 
 
 #define USB_VENDER_ID_REALTEK		0x0BDA
+#define USB_VENDER_ID_DLINK 		0x2001
 
 
 /* DID_USB_v916_20130116 */
@@ -146,6 +147,9 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_REALTEK, 0x8832, 0xff, 0xff, 0xff), .driver_info = RTL8852A},
 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_REALTEK, 0x885A, 0xff, 0xff, 0xff), .driver_info = RTL8852A},
 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_REALTEK, 0x885C, 0xff, 0xff, 0xff), .driver_info = RTL8852A},
+
+	/*=== D-Link DWA-X1850 ====*/
+	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_DLINK,   0x3321, 0xff, 0xff, 0xff), .driver_info = RTL8852A},
 #endif /* CONFIG_RTL8852A */
 
 #ifdef CONFIG_RTL8852B


### PR DESCRIPTION
add USB VID/PID 0x2001 0x3321 for
D-Link AX1800 USB adapter based on RTL8832AU

compiled and tested on Ubuntu; LED is not working

Signed-off-by: Sebastian Schaper <openwrt@sebastianschaper.net>